### PR TITLE
adding query limit list in search coffees

### DIFF
--- a/backend/src/app/domain/controllers/CoffeeController.ts
+++ b/backend/src/app/domain/controllers/CoffeeController.ts
@@ -59,29 +59,44 @@ export class CoffeeController {
   }
 
   public async profile(req: Request, res: Response) {
-    const { page = 1 } = req.query
+    const { page = 1, limit = 10 } = req.query
     const { id } = req.session
 
-    const coffees = await CoffeeService.getAllByAuthor((page as number), id)
+    const coffees = await CoffeeService.getAllByAuthor(
+      +page,
+      +limit,
+      id
+    )
 
     return res.status(200).json(coffees)
   }
 
   public async index(req: Request, res: Response) {
-    const { page = 1, type, preparation } = req.query
+    const { page = 1, limit = 10, type, preparation } = req.query
 
     if (!type && !preparation)
       return res.status(200).json(
-        await CoffeeService.getAllBy((page as number))
+        await CoffeeService.getAllBy(
+          +page,
+          +limit
+        )
       )
 
     if (preparation)
       return res.status(200).json(
-        await CoffeeService.getAllByPreparation((page as number), preparation as string)
+        await CoffeeService.getAllByPreparation(
+          +page,
+          +limit,
+          preparation as string
+        )
       )
     else
       return res.status(200).json(
-        await CoffeeService.getAllByType((page as number), (type as string))
+        await CoffeeService.getAllByType(
+          +page,
+          +limit,
+          type as string
+        )
       )
   }
 

--- a/backend/src/app/domain/services/CoffeeService.spec.ts
+++ b/backend/src/app/domain/services/CoffeeService.spec.ts
@@ -69,7 +69,7 @@ describe('Service Coffee', () => {
       author: user.id
     })
 
-    const coffees = await CoffeeService.getAllByType(1, coffeeType)
+    const coffees = await CoffeeService.getAllByType(1, 10, coffeeType)
 
     expect(coffees).toStrictEqual(
       expect.objectContaining({
@@ -98,7 +98,7 @@ describe('Service Coffee', () => {
       author: user2.id
     })
 
-    const coffees = await CoffeeService.getAllByAuthor(1, user1.id)
+    const coffees = await CoffeeService.getAllByAuthor(1, 5, user1.id)
 
     expect(coffees).toStrictEqual(
       expect.objectContaining({
@@ -131,7 +131,7 @@ describe('Service Coffee', () => {
       author: user2.id
     })
 
-    const coffees = await CoffeeService.getAllByPreparation(1, sentence)
+    const coffees = await CoffeeService.getAllByPreparation(1, 10, sentence)
 
     expect(coffees).toStrictEqual(
       expect.objectContaining({

--- a/backend/src/app/domain/services/CoffeeService.ts
+++ b/backend/src/app/domain/services/CoffeeService.ts
@@ -17,8 +17,6 @@ type CoffeeData = {
 }
 
 export class CoffeeService {
-  private readonly totalDocs = 20
-
   public constructor(private _repository: ICoffeeRepository<ICoffeeEntity, IValueObject>) {}
 
   public async create(coffee: CoffeeData) {
@@ -51,21 +49,21 @@ export class CoffeeService {
     return await this._repository.findById(ObjectID.toObjectID(id))
   }
 
-  public async getAllByType(page: number, type: string) {
-    return this.getAllBy(page, { type: TypeCoffe.toType(type) })
+  public async getAllByType(page: number, limit: number, type: string) {
+    return this.getAllBy(page, limit, { type: TypeCoffe.toType(type) })
   }
 
-  public async getAllByAuthor(page: number, id: string) {
-    return this.getAllBy(page, { author: ObjectID.toObjectID(id) })
+  public async getAllByAuthor(page: number, limit: number, id: string) {
+    return this.getAllBy(page, limit, { author: ObjectID.toObjectID(id) })
   }
 
-  public async getAllByPreparation(page: number, preparation: string) {
-    return this.getAllBy(page, { preparation: Preparation.toPreparation(preparation) })
+  public async getAllByPreparation(page: number, limit: number, preparation: string) {
+    return this.getAllBy(page, limit, { preparation: Preparation.toPreparation(preparation) })
   }
 
-  public async getAllBy(page: number, params: {} = {}) {
+  public async getAllBy(page: number, limit: number, params: {} = {}) {
     const { docs, pages, total } = await this._repository.findAll(
-      page, this.totalDocs, params
+      page, limit, params
     )
 
     const coffees = await Promise.all(docs.map(coffee => coffee.data()))


### PR DESCRIPTION
Esta PR adiciona a possibilidade ao cliente enviar como query na listagem de cafés o parâmetro `limit`, que determina a quantidade de registros.